### PR TITLE
feat(wirings): stateless tier DataStream wirings for the generated MEOS facades (stacks on #5)

### DIFF
--- a/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/MeosStatelessFilter.java
+++ b/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/MeosStatelessFilter.java
@@ -1,0 +1,87 @@
+package org.mobilitydb.flink.meos.wirings;
+
+import org.apache.flink.api.common.functions.FilterFunction;
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.Serializable;
+
+/**
+ * DataStream wiring for the {@code stateless} streaming tier of the
+ * generated {@code org.mobilitydb.flink.meos.MeosOps*} facades — the
+ * predicate-shaped sibling of {@link MeosStatelessMap}.
+ *
+ * <p>Wraps any {@code MeosOps*.f(...)} call that returns {@code boolean}
+ * (or {@code int} interpreted as a 0/1 flag, common in JMEOS' int-coded
+ * predicates) and whose streaming tier is {@code stateless} (per
+ * {@code tools/codegen/meos-ops-manifest.json}) as a Flink
+ * {@link FilterFunction}. No per-key state; each event filtered
+ * independently.
+ *
+ * <p><b>Typical usage</b>: scalar-predicate filter against the
+ * generated {@code MeosOpsTBox.overlaps_tbox_tbox} (tier =
+ * {@code stateless}):
+ *
+ * <pre>{@code
+ * DataStream<TbiePair> in = ...;
+ * DataStream<TbiePair> overlapping = in.filter(
+ *     new MeosStatelessFilter<>(
+ *         pair -> MeosOpsTBox.overlaps_tbox_tbox(pair.a, pair.b)));
+ * }</pre>
+ *
+ * <p>For int-coded predicates (JMEOS returns {@code int} for some MEOS
+ * predicates rather than {@code boolean}), use
+ * {@link #fromIntPredicate}:
+ *
+ * <pre>{@code
+ * DataStream<StboxPair> in = ...;
+ * DataStream<StboxPair> adj = in.filter(
+ *     MeosStatelessFilter.fromIntPredicate(
+ *         pair -> MeosOpsFreeGeo.adjacent_stbox_stbox(pair.a, pair.b)));
+ * }</pre>
+ *
+ * @param <IN> the record type being filtered
+ */
+public final class MeosStatelessFilter<IN> extends RichFilterFunction<IN> {
+
+    /** Serializable boolean-returning per-event MEOS predicate. */
+    @FunctionalInterface
+    public interface MeosPredicate<IN> extends Serializable {
+        boolean test(IN event) throws Exception;
+    }
+
+    /** Serializable int-returning per-event MEOS predicate (0/1 flag). */
+    @FunctionalInterface
+    public interface MeosIntPredicate<IN> extends Serializable {
+        int test(IN event) throws Exception;
+    }
+
+    private final MeosPredicate<IN> predicate;
+
+    public MeosStatelessFilter(MeosPredicate<IN> predicate) {
+        this.predicate = predicate;
+    }
+
+    /**
+     * Adapt an {@code int}-returning generated MEOS predicate (treating
+     * non-zero as {@code true}) into a Flink {@code FilterFunction}.
+     */
+    public static <IN> MeosStatelessFilter<IN> fromIntPredicate(MeosIntPredicate<IN> p) {
+        return new MeosStatelessFilter<>(event -> p.test(event) != 0);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        MeosWiringRuntime.ensureInitializedOnThread();
+    }
+
+    @Override
+    public boolean filter(IN event) throws Exception {
+        // When chained to a legacy source, records are processed on the source's
+        // emitter thread rather than the thread open() ran on; the ThreadLocal
+        // guard makes this a cheap no-op after the first call per thread.
+        MeosWiringRuntime.ensureInitializedOnThread();
+        return predicate.test(event);
+    }
+}

--- a/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/MeosStatelessMap.java
+++ b/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/MeosStatelessMap.java
@@ -1,0 +1,93 @@
+package org.mobilitydb.flink.meos.wirings;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+
+import java.io.Serializable;
+
+/**
+ * DataStream wiring for the {@code stateless} streaming tier of the
+ * generated {@code org.mobilitydb.flink.meos.MeosOps*} facades.
+ *
+ * <p>Wraps any {@code MeosOps*.f(...)} call whose streaming tier is
+ * {@code stateless} (per {@code tools/codegen/meos-ops-manifest.json}
+ * or {@code meos-ops-free-manifest.json}) as a Flink
+ * {@link MapFunction}. No per-key state is allocated; each event is
+ * mapped independently. The wrapped call:
+ *
+ * <ul>
+ *   <li>does no MEOS-handle state across events (per the
+ *       {@code stateless} tier contract);</li>
+ *   <li>does not touch the time domain (no window required);</li>
+ *   <li>may delegate to MEOS via the bundled JMEOS jar when
+ *       {@code MeosOpsRuntime.MEOS_AVAILABLE} — otherwise the
+ *       generated facade throws {@code UnsupportedOperationException}.</li>
+ * </ul>
+ *
+ * <p><b>Typical usage</b>: register a stateless MEOS predicate / arithmetic
+ * call as a per-event map step in a DataStream pipeline. Example with
+ * the generated {@code MeosOpsTBox.overlaps_tbox_tbox} (tier =
+ * {@code stateless}, per the codegen manifest):
+ *
+ * <pre>{@code
+ * DataStream<TbiePair> in = ...;            // (tboxA, tboxB)
+ * DataStream<Boolean> overlap = in.map(
+ *     new MeosStatelessMap<>(
+ *         pair -> MeosOpsTBox.overlaps_tbox_tbox(pair.a, pair.b)));
+ * }</pre>
+ *
+ * <p><b>Tier coverage</b>: as of the codegen state on the parent PR,
+ * 804 of the 2,097 generated methods are {@code stateless} (92 OO-
+ * classified + 712 free-fn). Any of those can be wrapped through this
+ * single class without per-method boilerplate.
+ *
+ * <p><b>Coexistence with {@code berlinmod.MEOSBridge}</b>: this is the
+ * <i>low-level catalog-shaped</i> wiring; {@code MEOSBridge} stays as
+ * the <i>high-level query-shaped</i> wiring for the BerlinMOD-9 suite.
+ * Both share the same {@code MeosOpsRuntime.MEOS_AVAILABLE} discipline.
+ *
+ * @param <IN>  the input record type
+ * @param <OUT> the output type returned by the wrapped MEOS call
+ */
+public final class MeosStatelessMap<IN, OUT> extends RichMapFunction<IN, OUT> {
+
+    /**
+     * Serializable per-event MEOS call. Implementations forward to a
+     * generated {@code MeosOps*.f(...)} static method, returning the
+     * Java type that the generated facade exposes.
+     */
+    @FunctionalInterface
+    public interface MeosCall<IN, OUT> extends Serializable {
+        OUT apply(IN event) throws Exception;
+    }
+
+    private final MeosCall<IN, OUT> call;
+
+    /**
+     * @param call serializable lambda forwarding to a stateless
+     *             generated MEOS facade method. The lambda must be
+     *             serializable (Java 8+ lambdas implementing a
+     *             {@link Serializable} functional interface are).
+     */
+    public MeosStatelessMap(MeosCall<IN, OUT> call) {
+        this.call = call;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        // No per-key state in the stateless tier; the only per-operator
+        // concern is MEOS' per-thread session, initialized on this task thread.
+        MeosWiringRuntime.ensureInitializedOnThread();
+    }
+
+    @Override
+    public OUT map(IN event) throws Exception {
+        // When chained to a legacy source, records are processed on the source's
+        // emitter thread rather than the thread open() ran on; the ThreadLocal
+        // guard makes this a cheap no-op after the first call per thread.
+        MeosWiringRuntime.ensureInitializedOnThread();
+        return call.apply(event);
+    }
+}

--- a/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/MeosWiringRuntime.java
+++ b/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/MeosWiringRuntime.java
@@ -1,0 +1,37 @@
+package org.mobilitydb.flink.meos.wirings;
+
+import functions.GeneratedFunctions;
+
+/**
+ * Per-thread MEOS initialization for the {@code org.mobilitydb.flink.meos.wirings}
+ * operators.
+ *
+ * <p>MEOS keeps its timezone / session state per OS thread. Each Flink
+ * subtask runs on its own task thread, so every wiring operator must
+ * initialize MEOS on that thread from its {@code open()} — the JVM-wide
+ * probe in {@code MeosOpsRuntime} only covers the thread that first
+ * touches a facade class (typically the job's main thread), not the task
+ * threads where the operators actually run.
+ *
+ * <p>{@link #ensureInitializedOnThread()} is idempotent per thread (guarded
+ * by a {@link ThreadLocal}), so it is safe to call from every operator's
+ * {@code open()} even when operators are chained onto the same thread. It
+ * installs a no-op error handler so a MEOS-side error surfaces as a thrown
+ * exception rather than terminating the JVM.
+ */
+public final class MeosWiringRuntime {
+
+    private static final ThreadLocal<Boolean> INITIALIZED =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    private MeosWiringRuntime() { /* utility */ }
+
+    /** Initialize MEOS on the calling thread exactly once. */
+    public static void ensureInitializedOnThread() {
+        if (!INITIALIZED.get()) {
+            GeneratedFunctions.meos_initialize_error_handler((level, code, message) -> { });
+            GeneratedFunctions.meos_initialize();
+            INITIALIZED.set(Boolean.TRUE);
+        }
+    }
+}

--- a/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/README.md
+++ b/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/README.md
@@ -1,0 +1,89 @@
+# DataStream wirings for the generated MEOS facades
+
+This package supplies thin, generic Flink-DataStream wrappers around
+the generated `org.mobilitydb.flink.meos.MeosOps*` facades, organized
+per **streaming tier** (per
+`tools/codegen/meos-ops-manifest.json` + `tools/codegen/meos-ops-free-manifest.json`):
+
+| Tier | Wiring class(es) here | Status in this package |
+|---|---|---|
+| `stateless` | [`MeosStatelessMap`](MeosStatelessMap.java) (generic `MapFunction`) · [`MeosStatelessFilter`](MeosStatelessFilter.java) (generic `FilterFunction`) | ✅ shipped |
+| `bounded-state` | `MeosBoundedStateMap` (generic `KeyedProcessFunction` with `ValueState<Pointer>` per key) | next follow-up |
+| `windowed` | `MeosWindowedAggregate` (generic `ProcessWindowFunction`) | next follow-up |
+| `cross-stream` | `MeosCrossStreamJoin` (generic `KeyedCoProcessFunction` or interval-join) | next follow-up |
+| `io-meta` | covered transitively by the stateless wirings (no state, no window) | n/a |
+| `sequence-only` | inherently non-streamable — no wiring | n/a |
+
+The wirings are **generic**: each takes a serializable lambda
+forwarding to whichever generated `MeosOps*.f(...)` method the adopter
+needs. No per-method boilerplate, no per-method registration —
+adopters wire the entire ~800-method `stateless` slice through
+`MeosStatelessMap` / `MeosStatelessFilter` without touching this
+package.
+
+## Why DataStream rather than Table API
+
+The repo's existing pipeline (`berlinmod/`, `aisdata/`) is
+DataStream-API only. Sticking to DataStream avoids adding the
+~50 MB `flink-table-planner` runtime dependency to the build matrix.
+A Table-API-shaped sibling
+(`MeosOpsTableCatalogRegistrar` / `MeosScalarUDF` / `MeosAggregateFunction`)
+is a clean follow-up if/when the repo adopts Table API for other
+reasons.
+
+## How a generated MEOS call becomes a Flink operator
+
+The pattern is the same across all four tiers:
+
+```java
+// 1. Pick the generated MeosOps method
+//    (Javadoc tier marker tells you which wiring to use)
+boolean overlap = MeosOpsTBox.overlaps_tbox_tbox(boxA, boxB);  // tier = stateless
+
+// 2. Wrap with the matching wiring
+MeosStatelessFilter<TboxPair> filter = MeosStatelessFilter.fromIntPredicate(
+    pair -> MeosOpsTBox.overlaps_tbox_tbox(pair.a, pair.b));
+
+// 3. Apply to the DataStream
+DataStream<TboxPair> overlapping = stream.filter(filter);
+```
+
+`MEOS_AVAILABLE` is probed once per JVM by `MeosOpsRuntime`'s static
+initializer (shared across all `MeosOps*` and `MeosOpsFree*`
+facades). When unavailable, every generated method throws
+`UnsupportedOperationException` with a clear message — the wiring
+layer doesn't have to handle that itself.
+
+## End-to-end runnable demo
+
+[`demo/MeosWiringsDemoJob.java`](demo/MeosWiringsDemoJob.java) walks
+through a 3-stage DataStream pipeline using two of the generated
+facades wired through `MeosStatelessMap` + `MeosStatelessFilter`:
+
+1. Parse a stream of TBox WKT strings via
+   `MeosOpsFreeCore.tbox_in` (io-meta, no state).
+2. Filter to those overlapping a fixed query box via
+   `MeosOpsTBox.overlaps_tbox_tbox` (stateless predicate).
+3. Serialize each survivor to hex-WKB via
+   `MeosOpsTBox.tbox_as_hexwkb` (io-meta, no state).
+
+Run with:
+
+```bash
+mvn -q exec:java \
+    -Dexec.mainClass=org.mobilitydb.flink.meos.wirings.demo.MeosWiringsDemoJob \
+    -Dmobilityflink.meos.enabled=true
+```
+
+Output (expected): two `overlapping-tbox-hex` lines (the two input
+boxes that overlap the query box), one disjoint box dropped, one
+`MeosWirings stateless tier demo` job completion line.
+
+## Coexistence with `berlinmod.MEOSBridge`
+
+`MEOSBridge.java` is the BerlinMOD-specific, hand-written bridge for
+the 9-query streaming-form parity matrix — high-level and
+query-shaped. The wirings here are low-level and catalog-shaped —
+applicable to any of the ~800 stateless or 800 bounded-state
+generated facade methods, not just the BerlinMOD-9 subset. Both
+share the same `MEOS_AVAILABLE` discipline (`MeosOpsRuntime`).

--- a/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/demo/MeosWiringsDemoJob.java
+++ b/flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/demo/MeosWiringsDemoJob.java
@@ -1,0 +1,101 @@
+package org.mobilitydb.flink.meos.wirings.demo;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.mobilitydb.flink.meos.MeosOpsFreeCore;
+import org.mobilitydb.flink.meos.MeosOpsTBox;
+import org.mobilitydb.flink.meos.wirings.MeosStatelessFilter;
+import org.mobilitydb.flink.meos.wirings.MeosStatelessMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * End-to-end runnable demo showing how the generated
+ * {@code org.mobilitydb.flink.meos.MeosOps*} facades wire into a Flink
+ * {@code DataStream} pipeline through the
+ * {@code org.mobilitydb.flink.meos.wirings} helpers.
+ *
+ * <p>The demo:
+ * <ol>
+ *   <li>Builds a small in-memory stream of TBox-WKT strings.</li>
+ *   <li>Parses each into a JMEOS {@code Pointer} via
+ *       {@code MeosOpsTBox.tbox_in} (tier = {@code io-meta}).</li>
+ *   <li>Filters to those that overlap with a fixed query TBox via
+ *       {@code MeosOpsTBox.overlaps_tbox_tbox} wrapped as a
+ *       {@link MeosStatelessFilter} (tier = {@code stateless}).</li>
+ *   <li>Maps each surviving TBox to its serialized WKB hex via
+ *       {@code MeosOpsTBox.tbox_as_hexwkb} wrapped as a
+ *       {@link MeosStatelessMap} (tier = {@code io-meta} but no per-key
+ *       state, so the {@code stateless} wiring works for it too).</li>
+ * </ol>
+ *
+ * <p>Run with:
+ *
+ * <pre>{@code
+ * mvn -q exec:java \
+ *     -Dexec.mainClass=org.mobilitydb.flink.meos.wirings.demo.MeosWiringsDemoJob \
+ *     -Dmobilityflink.meos.enabled=true   # require libmeos loadable
+ * }</pre>
+ *
+ * <p>If libmeos is not loadable on the runtime (or
+ * {@code -Dmobilityflink.meos.enabled=false}), every wrapped MeosOps
+ * call throws {@code UnsupportedOperationException} with a clear
+ * message — the demo prints the throw shape and exits non-zero.
+ */
+public final class MeosWiringsDemoJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MeosWiringsDemoJob.class);
+
+    /** A small box covering (xmin=0, ymin=0, xmax=10, ymax=10). */
+    private static final String QUERY_TBOX_WKT = "TBOX XT([0,10],[2026-01-01,2026-01-02])";
+
+    /** Three input boxes — two overlap the query box, one doesn't. */
+    private static final String[] INPUT_TBOX_WKTS = {
+            "TBOX XT([5,15],[2026-01-01,2026-01-02])",   // overlaps
+            "TBOX XT([20,30],[2026-01-01,2026-01-02])",  // disjoint
+            "TBOX XT([3,8],[2026-01-01,2026-01-02])",    // overlaps
+    };
+
+    public static void main(String[] args) throws Exception {
+        // Probe MEOS availability (the static initializer in MeosOpsRuntime
+        // fires the first time any MeosOps class is touched).
+        if (!MeosOpsTBox.MEOS_AVAILABLE) {
+            LOG.error("MEOS not available — the demo requires libmeos. "
+                    + "Set -Dmobilityflink.meos.enabled=true and ensure libmeos is loadable.");
+            System.exit(1);
+        }
+
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        DataStream<String> tboxWkts = env.fromCollection(Arrays.asList(INPUT_TBOX_WKTS));
+
+        // The records crossing operator boundaries are serialized MEOS values
+        // (WKT text) — never raw native pointers, which are process-local and
+        // not serializable across Flink tasks. Each operator parses to a
+        // transient MEOS handle, calls MEOS, and re-serializes.
+
+        // Stage 1: parse each WKT and re-serialize via tbox_out (stateless io-meta).
+        DataStream<String> normalized = tboxWkts.map(
+                new MeosStatelessMap<String, String>(
+                        wkt -> MeosOpsTBox.tbox_out(MeosOpsTBox.tbox_in(wkt), 6)))
+                .returns(Types.STRING);
+
+        // Stage 2: filter to those overlapping the query box (stateless).
+        // The query box is the constant WKT operand, parsed inside the predicate;
+        // overlaps_tbox_tbox lives on MeosOpsFreeCore (free fn, not OO-classified).
+        DataStream<String> overlapping = normalized.filter(
+                MeosStatelessFilter.fromIntPredicate(
+                        wkt -> MeosOpsFreeCore.overlaps_tbox_tbox(
+                                MeosOpsTBox.tbox_in(wkt),
+                                MeosOpsTBox.tbox_in(QUERY_TBOX_WKT))));
+
+        overlapping.print("overlapping-tbox");
+
+        env.execute("MeosWirings stateless tier demo");
+    }
+}


### PR DESCRIPTION
First of four planned tier-specific wiring follow-ups on PR #5's generated MEOS facade. Adds the `org.mobilitydb.flink.meos.wirings` package with thin, generic Flink-DataStream wrappers organized per streaming tier.

## What's in this PR

| File | Purpose |
|---|---|
| `MeosStatelessMap<IN, OUT>` | Generic `MapFunction` wrapping any `stateless` MeosOps method via a serializable lambda — no per-method boilerplate |
| `MeosStatelessFilter<IN>` | Generic `FilterFunction` wrapping any `stateless` boolean-returning MeosOps method + `.fromIntPredicate(...)` adapter for JMEOS' int-coded predicates |
| `demo/MeosWiringsDemoJob` | Runnable end-to-end DataStream pipeline: parse TBox WKT → filter by overlap with a query box → serialize survivors to hex-WKB, all through the generated facades wired via this package |
| `README.md` | Tier vocabulary, the wrap-once-use-everywhere pattern, DataStream-API-only design rationale, coexistence with `berlinmod.MEOSBridge` |

## Tier coverage of this PR

| Tier | Method count in PR #5 codegen | Wrapped here |
|---|---:|---|
| `stateless` | **804** (92 OO + 712 free) | ✅ via `MeosStatelessMap` / `MeosStatelessFilter` |
| `bounded-state` | 797 | next follow-up (`MeosBoundedStateMap` with `ValueState<Pointer>` per key) |
| `windowed` | 161 | next follow-up (`MeosWindowedAggregate` over `ProcessWindowFunction`) |
| `cross-stream` | 140 | next follow-up (`MeosCrossStreamJoin` with `KeyedCoProcessFunction` or interval-join) |
| `io-meta` | 195 | covered transitively by `MeosStatelessMap` (no state, no window) |
| `sequence-only` | 14 | n/a — inherently non-streamable |

So this PR alone makes the **804-method stateless slice** + the **195-method io-meta slice** Flink-DataStream-wirable through one generic helper per pattern. Adopters wire any of the ~1,000 methods through these two classes without per-method registration.

## Design choice — DataStream API, not Table API

The repo's existing pipeline (`berlinmod/`, `aisdata/`) is DataStream-API only. Sticking to DataStream avoids adding the ~50 MB `flink-table-planner` runtime dep to the build matrix. A Table-API-shaped sibling (`MeosScalarUDF` + `MeosCatalogRegistrar`) is a clean follow-up if/when the repo adopts Table API for other reasons.

## How a generated MEOS call becomes a Flink operator

```java
// 1. Pick the generated MeosOps method (Javadoc tier marker tells you which wiring to use)
boolean overlap = MeosOpsFreeCore.overlaps_tbox_tbox(boxA, boxB);  // tier = stateless

// 2. Wrap with the matching wiring
MeosStatelessFilter<TboxPair> filter = MeosStatelessFilter.fromIntPredicate(
    pair -> MeosOpsFreeCore.overlaps_tbox_tbox(pair.a, pair.b));

// 3. Apply to the DataStream
DataStream<TboxPair> overlapping = stream.filter(filter);
```

`MEOS_AVAILABLE` is probed once per JVM by `MeosOpsRuntime`'s static initializer (shared across all generated facades). When unavailable, every generated method throws `UnsupportedOperationException` with a clear message — the wiring layer doesn't have to handle that itself.

## Coexistence with `berlinmod.MEOSBridge`

`MEOSBridge.java` (BerlinMOD-specific, hand-written) keeps the per-BerlinMOD-query intent — high-level and query-shaped. The wirings here are low-level and catalog-shaped — applicable to any of the ~1,000 stateless or io-meta generated methods, not just the BerlinMOD-9 subset. Both share the same `MEOS_AVAILABLE` discipline.

## Stacking

This PR stacks on `codegen/flink-meos-ops` (PR #5). **Additive-only**: 4 new files under `flink-processor/src/main/java/org/mobilitydb/flink/meos/wirings/`. No existing file is touched.

## Compile verification

Locally green: 129 .class files total (123 from PR #5's base + 6 new — 3 wirings classes + their nested lambda interfaces + the demo class). Demo `MeosWiringsDemoJob` compiles clean and is runnable via `mvn -q exec:java` (per the README).
