### PR TITLE
build(meos): select the extended temporal-type families via MobilityDB/MEOS build flags (stacks on #15)

### DIFF
--- a/flink-processor/pom.xml
+++ b/flink-processor/pom.xml
@@ -216,4 +216,318 @@
             </plugin>
         </plugins>
     </build>
+
+    <!-- Optional extended temporal-type families, mirroring the MobilityDB/MEOS
+         CMake build flags. Family inclusion is selected at build time with the
+         same uppercase flag names and ON|OFF (also 1|0) values as MEOS:
+           -DCBUFFER=ON -DNPOINT=OFF -DPOSE=ON -DRGEO=ON -DH3=ON
+         Defaults match MEOS: NPOINT is included by default; CBUFFER, POSE, RGEO,
+         and H3 are excluded unless their flag is ON|1. RGEO requires POSE (enable
+         both). When a family is excluded, its generated MeosOps* facade sources
+         and its smoke test are dropped from the build. -->
+    <profiles>
+        <profile>
+            <id>cbuffer-exclude-unset</id>
+            <activation>
+                <property><name>!CBUFFER</name></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTCbuffer.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeCbuffer.java</exclude>
+                                <exclude>**/meos/MeosOpsCbufferSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosCbufferSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>cbuffer-exclude-off</id>
+            <activation>
+                <property><name>CBUFFER</name><value>OFF</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTCbuffer.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeCbuffer.java</exclude>
+                                <exclude>**/meos/MeosOpsCbufferSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosCbufferSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>cbuffer-exclude-zero</id>
+            <activation>
+                <property><name>CBUFFER</name><value>0</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTCbuffer.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeCbuffer.java</exclude>
+                                <exclude>**/meos/MeosOpsCbufferSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosCbufferSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pose-exclude-unset</id>
+            <activation>
+                <property><name>!POSE</name></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTPose.java</exclude>
+                                <exclude>**/meos/MeosOpsFreePose.java</exclude>
+                                <exclude>**/meos/MeosOpsPoseSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosPoseSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pose-exclude-off</id>
+            <activation>
+                <property><name>POSE</name><value>OFF</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTPose.java</exclude>
+                                <exclude>**/meos/MeosOpsFreePose.java</exclude>
+                                <exclude>**/meos/MeosOpsPoseSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosPoseSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pose-exclude-zero</id>
+            <activation>
+                <property><name>POSE</name><value>0</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTPose.java</exclude>
+                                <exclude>**/meos/MeosOpsFreePose.java</exclude>
+                                <exclude>**/meos/MeosOpsPoseSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosPoseSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>rgeo-exclude-unset</id>
+            <activation>
+                <property><name>!RGEO</name></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTRGeometry.java</exclude>
+                                <exclude>**/meos/MeosOpsTRGeometryInst.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeRgeo.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>rgeo-exclude-off</id>
+            <activation>
+                <property><name>RGEO</name><value>OFF</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTRGeometry.java</exclude>
+                                <exclude>**/meos/MeosOpsTRGeometryInst.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeRgeo.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>rgeo-exclude-zero</id>
+            <activation>
+                <property><name>RGEO</name><value>0</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTRGeometry.java</exclude>
+                                <exclude>**/meos/MeosOpsTRGeometryInst.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeRgeo.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>h3-exclude-unset</id>
+            <activation>
+                <property><name>!H3</name></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTh3index.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeH3.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>h3-exclude-off</id>
+            <activation>
+                <property><name>H3</name><value>OFF</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTh3index.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeH3.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>h3-exclude-zero</id>
+            <activation>
+                <property><name>H3</name><value>0</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTh3index.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeH3.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>npoint-exclude-off</id>
+            <activation>
+                <property><name>NPOINT</name><value>OFF</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTNpoint.java</exclude>
+                                <exclude>**/meos/MeosOpsTNpointInst.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeNpoint.java</exclude>
+                                <exclude>**/meos/MeosOpsNpointSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosNpointSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>npoint-exclude-zero</id>
+            <activation>
+                <property><name>NPOINT</name><value>0</value></property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>**/meos/MeosOpsTNpoint.java</exclude>
+                                <exclude>**/meos/MeosOpsTNpointInst.java</exclude>
+                                <exclude>**/meos/MeosOpsFreeNpoint.java</exclude>
+                                <exclude>**/meos/MeosOpsNpointSet.java</exclude>
+                            </excludes>
+                            <testExcludes combine.children="append">
+                                <testExclude>**/MeosNpointSmokeTest.java</testExclude>
+                            </testExcludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosCbufferSmokeTest.java
+++ b/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosCbufferSmokeTest.java
@@ -1,0 +1,40 @@
+package org.mobilitydb.flink.meos;
+
+import functions.GeneratedFunctions;
+import jnr.ffi.Pointer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Runtime check that the cbuffer facade family calls into libmeos and returns
+ * correct results. Compiled and run only when the build includes the cbuffer
+ * family ({@code -DCBUFFER=ON}); the family requires a libmeos built with
+ * {@code -DCBUFFER=ON}.
+ */
+@EnabledIfSystemProperty(named = "mobilityflink.meos.enabled", matches = "true")
+class MeosCbufferSmokeTest {
+
+    @BeforeAll
+    static void init() {
+        GeneratedFunctions.meos_initialize_error_handler((level, code, message) -> { });
+        GeneratedFunctions.meos_initialize();
+    }
+
+    @AfterAll
+    static void finalizeMeos() {
+        GeneratedFunctions.meos_finalize();
+    }
+
+    @Test
+    void cbuffer() {
+        Pointer cb = MeosOpsFreeCbuffer.cbuffer_make(MeosOpsFreeGeo.geom_in("POINT(1 1)", 0), 0.5);
+        assertNotNull(cb);
+        assertEquals(0.5, MeosOpsFreeCbuffer.cbuffer_radius(cb), 1e-9);
+        assertNotNull(MeosOpsFreeCbuffer.cbuffer_out(cb, 6));
+    }
+}

--- a/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosFacadeSmokeTest.java
+++ b/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosFacadeSmokeTest.java
@@ -7,16 +7,18 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Per-family runtime check that the generated MEOS facade calls into libmeos and
- * returns correct results. Each family constructs a value through a {@code MeosOps*}
- * facade method and reads it back. Runs only with {@code -Dmobilityflink.meos.enabled=true}
- * and a libmeos on the load path; the extended families (cbuffer, npoint, pose) require a
- * libmeos built with {@code -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON}.
+ * Runtime check that the always-built MEOS facade families (core and geo) call
+ * into libmeos and return correct results. Each constructs a value through a
+ * {@code MeosOps*} facade method and reads it back. Runs only with
+ * {@code -Dmobilityflink.meos.enabled=true} and a libmeos on the load path. The
+ * optional families have their own gated smoke tests
+ * ({@link MeosCbufferSmokeTest}, {@link MeosNpointSmokeTest},
+ * {@link MeosPoseSmokeTest}), each compiled only when its build flag includes
+ * the family.
  */
 @EnabledIfSystemProperty(named = "mobilityflink.meos.enabled", matches = "true")
 class MeosFacadeSmokeTest {
@@ -60,29 +62,5 @@ class MeosFacadeSmokeTest {
         Pointer geom = MeosOpsFreeGeo.geom_in("POINT(1 1)", 0);
         assertNotNull(geom);
         assertTrue(MeosOpsFreeGeo.geo_as_text(geom, 6).toUpperCase().contains("POINT"));
-    }
-
-    @Test
-    void cbuffer() {
-        Pointer cb = MeosOpsFreeCbuffer.cbuffer_make(MeosOpsFreeGeo.geom_in("POINT(1 1)", 0), 0.5);
-        assertNotNull(cb);
-        assertEquals(0.5, MeosOpsFreeCbuffer.cbuffer_radius(cb), 1e-9);
-        assertNotNull(MeosOpsFreeCbuffer.cbuffer_out(cb, 6));
-    }
-
-    @Test
-    void npoint() {
-        Pointer np = MeosOpsFreeNpoint.npoint_make(1, 0.5);
-        assertNotNull(np);
-        assertEquals(1, MeosOpsFreeNpoint.npoint_route(np));
-        assertEquals(0.5, MeosOpsFreeNpoint.npoint_position(np), 1e-9);
-    }
-
-    @Test
-    void pose() {
-        Pointer pose = MeosOpsFreePose.pose_in("Pose(Point(1 1), 0.5)");
-        assertNotNull(pose);
-        assertNotNull(MeosOpsFreePose.pose_out(pose, 6));
-        assertEquals(0.5, MeosOpsFreePose.pose_rotation(pose), 1e-9);
     }
 }

--- a/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosNpointSmokeTest.java
+++ b/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosNpointSmokeTest.java
@@ -1,0 +1,39 @@
+package org.mobilitydb.flink.meos;
+
+import functions.GeneratedFunctions;
+import jnr.ffi.Pointer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Runtime check that the npoint facade family calls into libmeos and returns
+ * correct results. Compiled and run when the build includes the npoint family
+ * (the default; dropped with {@code -DNPOINT=OFF}).
+ */
+@EnabledIfSystemProperty(named = "mobilityflink.meos.enabled", matches = "true")
+class MeosNpointSmokeTest {
+
+    @BeforeAll
+    static void init() {
+        GeneratedFunctions.meos_initialize_error_handler((level, code, message) -> { });
+        GeneratedFunctions.meos_initialize();
+    }
+
+    @AfterAll
+    static void finalizeMeos() {
+        GeneratedFunctions.meos_finalize();
+    }
+
+    @Test
+    void npoint() {
+        Pointer np = MeosOpsFreeNpoint.npoint_make(1, 0.5);
+        assertNotNull(np);
+        assertEquals(1, MeosOpsFreeNpoint.npoint_route(np));
+        assertEquals(0.5, MeosOpsFreeNpoint.npoint_position(np), 1e-9);
+    }
+}

--- a/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosPoseSmokeTest.java
+++ b/flink-processor/src/test/java/org/mobilitydb/flink/meos/MeosPoseSmokeTest.java
@@ -1,0 +1,40 @@
+package org.mobilitydb.flink.meos;
+
+import functions.GeneratedFunctions;
+import jnr.ffi.Pointer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Runtime check that the pose facade family calls into libmeos and returns
+ * correct results. Compiled and run only when the build includes the pose
+ * family ({@code -DPOSE=ON}); the family requires a libmeos built with
+ * {@code -DPOSE=ON}.
+ */
+@EnabledIfSystemProperty(named = "mobilityflink.meos.enabled", matches = "true")
+class MeosPoseSmokeTest {
+
+    @BeforeAll
+    static void init() {
+        GeneratedFunctions.meos_initialize_error_handler((level, code, message) -> { });
+        GeneratedFunctions.meos_initialize();
+    }
+
+    @AfterAll
+    static void finalizeMeos() {
+        GeneratedFunctions.meos_finalize();
+    }
+
+    @Test
+    void pose() {
+        Pointer pose = MeosOpsFreePose.pose_in("Pose(Point(1 1), 0.5)");
+        assertNotNull(pose);
+        assertNotNull(MeosOpsFreePose.pose_out(pose, 6));
+        assertEquals(0.5, MeosOpsFreePose.pose_rotation(pose), 1e-9);
+    }
+}


### PR DESCRIPTION
The extended temporal-type families are selected at build time with the same uppercase flag names and ON|OFF (also 1|0) values as the MobilityDB/MEOS CMake build: NPOINT is included by default; CBUFFER, POSE, RGEO, and H3 are included with -D<FAMILY>=ON (or =1) and dropped otherwise (RGEO needs POSE). Each family's MeosOps* facade sources and its per-family smoke test (MeosCbufferSmokeTest, MeosNpointSmokeTest, MeosPoseSmokeTest) are excluded when the family is off; the core and geo smoke checks remain in MeosFacadeSmokeTest.