### PR TITLE
fix: upgrading functions to GeneratedFunctions to fit JMEOS updates

### DIFF
--- a/flink-processor/src/main/java/aisdata/Query1_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query1_Main.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 
@@ -165,8 +165,8 @@ public class Query1_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -231,7 +231,7 @@ public class Query1_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -275,15 +275,15 @@ public class Query1_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
             // Parse the INPolygons only once per worker.
             // geog_in(wkt, -1) creates a geography type (SRID=4326), so
             // edwithin_tgeo_geo computes distances geodetically in metres - consistent
             // with the tgeogpoint created below via tgeogpoint_in.
             this.hazardZones = new Pointer[zoneWkt.length];
             for (int i = 0; i < zoneWkt.length; i++) {
-                hazardZones[i] = functions.geog_in(zoneWkt[i], -1);
+                hazardZones[i] = GeneratedFunctions.geog_in(zoneWkt[i], -1);
                 if (hazardZones[i] == null) {
                     log.error("geog_in returned null for ZONE {}", i + 1);
                 }
@@ -335,7 +335,7 @@ public class Query1_Main {
                 String tpointWkt = String.format(
                         "POINT(%f %f)@%s", event.getLon(), event.getLat(), ts);
 
-                Pointer tpoint = functions.tgeogpoint_in(tpointWkt);
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(tpointWkt);
                 if (tpoint == null) {
                     log.error("tgeogpoint_in returned null for WKT: {}", tpointWkt);
                     continue;
@@ -346,7 +346,7 @@ public class Query1_Main {
 
                     // edwithin_tgeo_geo returns 1 if tpoint is within distanceMeters of the
                     // zone polygon at any instant — implements paper Line 2.
-                    int within = functions.edwithin_tgeo_geo(
+                    int within = GeneratedFunctions.edwithin_tgeo_geo(
                             tpoint, hazardZones[i], distanceMeters);
 
                     if (within == 1) {

--- a/flink-processor/src/main/java/aisdata/Query2_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query2_Main.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 
@@ -168,8 +168,8 @@ public class Query2_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -227,7 +227,7 @@ public class Query2_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -308,14 +308,14 @@ public class Query2_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
             // Parse the maintenance area polygons only once per worker.
             // geog_in(wkt, -1) creates a geography type (SRID=4326 implicit), consistent
             // with the tgeogpoint created by tgeogpoint_in below.
             maintenanceZones = new Pointer[maintenanceAreasWkt.length];
             for (int i = 0; i < maintenanceAreasWkt.length; i++) {
-                maintenanceZones[i] = functions.geog_in(maintenanceAreasWkt[i], -1);
+                maintenanceZones[i] = GeneratedFunctions.geog_in(maintenanceAreasWkt[i], -1);
                 if (maintenanceZones[i] == null) {
                     log.error("geog_in returned null for maintenance area {}", i + 1);
                 }
@@ -353,7 +353,7 @@ public class Query2_Main {
                 String tpointWkt = String.format(
                         "POINT(%f %f)@%s", event.getLon(), event.getLat(), ts);
 
-                Pointer tpoint = functions.tgeogpoint_in(tpointWkt);
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(tpointWkt);
                 if (tpoint == null) {
                     log.error("tgeogpoint_in returned null for WKT: {}", tpointWkt);
                     continue;
@@ -366,7 +366,7 @@ public class Query2_Main {
                 boolean inMaintenanceArea = false;
                 for (Pointer zone : maintenanceZones) {
                     if (zone == null) continue;
-                    if (functions.eintersects_tgeo_geo(tpoint, zone) == 1) {
+                    if (GeneratedFunctions.eintersects_tgeo_geo(tpoint, zone) == 1) {
                         inMaintenanceArea = true;
                         log.debug("MMSI={} skipped: point intersects maintenance area at ts={}",
                                 mmsi, ts);

--- a/flink-processor/src/main/java/aisdata/Query3_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query3_Main.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import functions.GeneratedFunctions;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.connector.kafka.source.KafkaSource;
@@ -25,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 
@@ -97,8 +98,8 @@ public class Query3_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -155,7 +156,7 @@ public class Query3_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -190,8 +191,8 @@ public class Query3_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
             log.info("MEOS initialized in TrajectoryCreationWindowFunction.open()");
         }
 
@@ -249,7 +250,7 @@ public class Query3_Main {
             // Step 4: parse the sequence into a native MEOS tgeogpoint pointer.
             // tgeogpoint_in accepts both single instants ("POINT(lon lat)@ts") and sequences
             // ("{POINT(...)@ts,...}"). Here we always pass a sequence.
-            Pointer trajectory = functions.tgeogpoint_in(seq.toString());
+            Pointer trajectory = GeneratedFunctions.tgeogpoint_in(seq.toString());
             if (trajectory == null) {
                 log.error("tgeogpoint_in returned null for sequence: {}", seq);
                 return;
@@ -259,7 +260,7 @@ public class Query3_Main {
             // tspatial_as_ewkt(pointer, maxdd) converts any temporal spatial type to EWKT
             // (WKT with SRID prefix), producing human-readable "POINT(lon lat)@ts" output.
             // maxdd=6 gives 6 decimal places.
-            String trajectoryWkt = functions.tspatial_as_ewkt(trajectory, 6);
+            String trajectoryWkt = GeneratedFunctions.tspatial_as_ewkt(trajectory, 6);
 
             /*
                 // We have this trajectory

--- a/flink-processor/src/main/java/aisdata/Query4_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query4_Main.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 
@@ -149,8 +149,8 @@ public class Query4_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -206,7 +206,7 @@ public class Query4_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -268,8 +268,8 @@ public class Query4_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
 
            // stbox_make parameters:
             //   hasx=true   → include spatial (XY) dimensions
@@ -279,12 +279,12 @@ public class Query4_Main {
             //   xmin/xmax/ymin/ymax → spatial bounds (lon/lat in degrees)
             //   zmin/zmax=0 → unused (hasz=false)
             //   s           → temporal span pointer (tstzspan)
-            Pointer tspan = functions.tstzspan_in(tspanLiteral);
+            Pointer tspan = GeneratedFunctions.tstzspan_in(tspanLiteral);
             if (tspan == null) {
                 log.error("tstzspan_in returned null for: {}", tspanLiteral);
                 return;
             }
-            stbox = functions.stbox_make(true, false, true, 4326,
+            stbox = GeneratedFunctions.stbox_make(true, false, true, 4326,
                     xmin, xmax, ymin, ymax, 0, 0, tspan);
             if (stbox == null) {
                 log.error("stbox_make returned null");
@@ -340,7 +340,7 @@ public class Query4_Main {
                 String tpointWkt = String.format(
                         "POINT(%f %f)@%s", event.getLon(), event.getLat(), ts);
 
-                Pointer tpoint = functions.tgeogpoint_in(tpointWkt);
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(tpointWkt);
                 if (tpoint == null) {
                     log.error("tgeogpoint_in returned null for WKT: {}", tpointWkt);
                     continue;
@@ -351,7 +351,7 @@ public class Query4_Main {
                 // Returns non-null → point is inside the STBox → keep.
                 // border_inc=true means the box boundaries are inclusive ([xmin,xmax],
                 // [ymin,ymax], [tsmin,tsmax]), matching the paper's closed-interval notation.
-                Pointer restricted = functions.tgeo_at_stbox(tpoint, stbox, true);
+                Pointer restricted = GeneratedFunctions.tgeo_at_stbox(tpoint, stbox, true);
                 if (restricted == null) {
                     log.debug("MMSI={} skipped: point outside STBox at ts={}", mmsi, ts);
                     continue;
@@ -375,13 +375,13 @@ public class Query4_Main {
             }
             seq.append("}");
 
-            Pointer trajectory = functions.tgeogpoint_in(seq.toString());
+            Pointer trajectory = GeneratedFunctions.tgeogpoint_in(seq.toString());
             if (trajectory == null) {
                 log.error("tgeogpoint_in returned null for sequence: {}", seq);
                 return;
             }
 
-            String trajectoryEwkt = functions.tspatial_as_ewkt(trajectory, 6);
+            String trajectoryEwkt = GeneratedFunctions.tspatial_as_ewkt(trajectory, 6);
 
             String output = String.format(
                     "[TRAJ][Q4] MMSI=%-12d | points=%3d | window [%s - %s]%n           trajectory: %s",

--- a/flink-processor/src/main/java/aisdata/Query5_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query5_Main.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 
@@ -168,8 +168,8 @@ public class Query5_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -232,7 +232,7 @@ public class Query5_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -299,11 +299,11 @@ public class Query5_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
 
             // geog_in(wkt, -1) → SRID=4326 geography, consistent with tgeogpoint_in.
-            geofence = functions.geog_in(geofenceWkt, -1);
+            geofence = GeneratedFunctions.geog_in(geofenceWkt, -1);
             if (geofence == null) {
                 log.error("geog_in returned null for geofence: {}", geofenceWkt);
             } else {
@@ -355,7 +355,7 @@ public class Query5_Main {
 
                 String ts = millisToTimestamp(event.getTimestamp());
 
-                Pointer tpoint = functions.tgeogpoint_in(
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", event.getLon(), event.getLat(), ts));
                 if (tpoint == null) {
                     log.error("tgeogpoint_in returned null for MMSI={} at ts={}", mmsi, ts);
@@ -364,7 +364,7 @@ public class Query5_Main {
 
                 // Paper Line 2: edwithin_tgeo_geo(lon, lat, ts, POLYGON, 1) == 1
                 // Distance=1m is effectively an intersection test.
-                if (functions.edwithin_tgeo_geo(tpoint, geofence, geofenceDistMeters) != 1) {
+                if (GeneratedFunctions.edwithin_tgeo_geo(tpoint, geofence, geofenceDistMeters) != 1) {
                     log.debug("MMSI={} skipped: outside geofence at ts={}", mmsi, ts);
                     continue;
                 }
@@ -405,9 +405,9 @@ public class Query5_Main {
             if (avgSpeedMs <= avgSpeedThresholdMs && minSpeedMs <= minSpeedThresholdMs) return;
 
             // Build trajectory for output.
-            Pointer trajectory = functions.tgeogpoint_in(seq.toString());
+            Pointer trajectory = GeneratedFunctions.tgeogpoint_in(seq.toString());
             String trajectoryEwkt = (trajectory != null)
-                    ? functions.tspatial_as_ewkt(trajectory, 6)
+                    ? GeneratedFunctions.tspatial_as_ewkt(trajectory, 6)
                     : seq.toString(); // fallback to raw WKT if MEOS parse fails
 
             String triggerReason = buildTriggerReason(avgSpeedMs, minSpeedMs);

--- a/flink-processor/src/main/java/aisdata/Query6_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query6_Main.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -108,8 +108,8 @@ public class Query6_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -176,7 +176,7 @@ public class Query6_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -211,8 +211,8 @@ public class Query6_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -222,9 +222,9 @@ public class Query6_Main {
             String tsRight = millisToTimestamp(right.getTimestamp());
 
             // Build tgeogpoint instants for both sides of the pair.
-            Pointer tpointLeft = functions.tgeogpoint_in(
+            Pointer tpointLeft = GeneratedFunctions.tgeogpoint_in(
                     String.format("POINT(%f %f)@%s", left.getLon(),  left.getLat(),  tsLeft));
-            Pointer tpointRight = functions.tgeogpoint_in(
+            Pointer tpointRight = GeneratedFunctions.tgeogpoint_in(
                     String.format("POINT(%f %f)@%s", right.getLon(), right.getLat(), tsRight));
 
             if (tpointLeft == null || tpointRight == null) {
@@ -252,15 +252,15 @@ public class Query6_Main {
             // WGS-84) between the two positions regardless of their timestamps. This is
             // equivalent to nad_tgeo_tgeo only when ts_left == ts_right. For ts_left !=
             // ts_right it is a spatial-only distance.
-            Pointer geoLeft  = functions.tgeo_end_value(tpointLeft);
-            Pointer geoRight = functions.tgeo_end_value(tpointRight);
+            Pointer geoLeft  = GeneratedFunctions.tgeo_end_value(tpointLeft);
+            Pointer geoRight = GeneratedFunctions.tgeo_end_value(tpointRight);
 
             if (geoLeft == null || geoRight == null) {
                 log.error("temporal_end_value returned null for MMSI={}", left.getMmsi());
                 return null;
             }
 
-            double mindist = functions.geog_distance(geoLeft, geoRight);
+            double mindist = GeneratedFunctions.geog_distance(geoLeft, geoRight);
 
             // Paper Line 5: filter(lat > 0.0): keep only pairs where left-side lat is positive.
             // All AIS positions in this dataset are in the Northern Hemisphere (~55–58°N),

--- a/flink-processor/src/main/java/aisdata/Query7_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query7_Main.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -118,8 +118,8 @@ public class Query7_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -184,7 +184,7 @@ public class Query7_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -232,8 +232,8 @@ public class Query7_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         /**
@@ -267,18 +267,18 @@ public class Query7_Main {
             List<Pointer> geoLefts  = new ArrayList<>(lefts.size());
             for (AISData left : lefts) {
                 String ts = millisToTimestamp(left.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", left.getLon(), left.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoLefts.add(geo); // null if tgeogpoint_in or temporal_end_value failed
             }
 
             List<Pointer> geoRights = new ArrayList<>(rights.size());
             for (AISData right : rights) {
                 String ts = millisToTimestamp(right.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", right.getLon(), right.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoRights.add(geo);
             }
 
@@ -303,7 +303,7 @@ public class Query7_Main {
                     // Paper Line 2: device_id < device_id2
                     if (left.getMmsi() >= right.getMmsi()) continue;
 
-                    double dist = functions.geog_distance(geoLeft, geoRight);
+                    double dist = GeneratedFunctions.geog_distance(geoLeft, geoRight);
 
                     // Keep only the minimum distance per unique (mmsi1, mmsi2) pair.
                     String key = left.getMmsi() + ":" + right.getMmsi();

--- a/flink-processor/src/main/java/aisdata/Query8_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query8_Main.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import functions.GeneratedFunctions;
 import org.apache.commons.math3.filter.DefaultMeasurementModel;
 import org.apache.commons.math3.filter.DefaultProcessModel;
 import org.apache.commons.math3.filter.KalmanFilter;
@@ -35,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -173,8 +174,8 @@ public class Query8_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -224,7 +225,7 @@ public class Query8_Main {
             throw e;
         } finally {
             try {
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -300,8 +301,8 @@ public class Query8_Main {
         @Override
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
         }
 
         /**
@@ -375,12 +376,12 @@ public class Query8_Main {
             rawSeq.append("}");
             smoothedSeq.append("}");
 
-            Pointer rawTraj      = functions.tgeogpoint_in(rawSeq.toString());
-            Pointer smoothedTraj = functions.tgeogpoint_in(smoothedSeq.toString());
+            Pointer rawTraj      = GeneratedFunctions.tgeogpoint_in(rawSeq.toString());
+            Pointer smoothedTraj = GeneratedFunctions.tgeogpoint_in(smoothedSeq.toString());
             if (rawTraj == null || smoothedTraj == null) return;
 
-            String rawEwkt      = functions.tspatial_as_ewkt(rawTraj,      6);
-            String smoothedEwkt = functions.tspatial_as_ewkt(smoothedTraj, 6);
+            String rawEwkt      = GeneratedFunctions.tspatial_as_ewkt(rawTraj,      6);
+            String smoothedEwkt = GeneratedFunctions.tspatial_as_ewkt(smoothedTraj, 6);
 
             String result = String.format(
                     "[EKF][Q8] MMSI=%-12d | points=%2d | gate=%.1f q=%.3f var=%.1f"

--- a/flink-processor/src/main/java/aisdata/Query9_Main.java
+++ b/flink-processor/src/main/java/aisdata/Query9_Main.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -95,8 +95,8 @@ public class Query9_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -158,7 +158,7 @@ public class Query9_Main {
             throw e;
         } finally {
             try {
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -204,8 +204,8 @@ public class Query9_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -224,18 +224,18 @@ public class Query9_Main {
             List<Pointer> geoLefts  = new ArrayList<>(lefts.size());
             for (AISData left : lefts) {
                 String ts = millisToTimestamp(left.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", left.getLon(), left.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoLefts.add(geo); // null if tgeogpoint_in or temporal_end_value failed
             }
 
             List<Pointer> geoRights = new ArrayList<>(rights.size());
             for (AISData right : rights) {
                 String ts = millisToTimestamp(right.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", right.getLon(), right.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoRights.add(geo);
             }
 
@@ -261,7 +261,7 @@ public class Query9_Main {
                     // Paper Line 2: device_id != device_id2
                     if (left.getMmsi() == right.getMmsi()) continue;
 
-                    double dist = functions.geog_distance(geoLeft, geoRight);
+                    double dist = GeneratedFunctions.geog_distance(geoLeft, geoRight);
 
                     // Key: directed pair "mmsi1→mmsi2"
                     String key = left.getMmsi() + "->" + right.getMmsi();

--- a/flink-processor/src/main/java/sncbdata/Query1_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query1_Main.java
@@ -16,7 +16,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.MeosErrorHandler;
 import functions.error_handler_fn;
 
@@ -70,8 +70,8 @@ public class Query1_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new MeosErrorHandler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new MeosErrorHandler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -115,7 +115,7 @@ public class Query1_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS library");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage());
             }
@@ -146,12 +146,12 @@ public class Query1_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             error_handler = new MeosErrorHandler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(error_handler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(error_handler);
             // Parse INPolygons once per worker: not per window call.
             this.hazardZones = new Pointer[zoneWkt.length];
             for (int i = 0; i < zoneWkt.length; i++) {
-                hazardZones[i] = functions.geog_in(zoneWkt[i], -1);
+                hazardZones[i] = GeneratedFunctions.geog_in(zoneWkt[i], -1);
                 if (hazardZones[i] == null) {
                     logger.error("geog_in returned null for ZONE {}", i + 1);
                 }
@@ -167,14 +167,14 @@ public class Query1_Main {
                 String ts = millisToTimestamp(event.getTimestamp());
                 String tpointWkt = String.format("POINT(%f %f)@%s", event.getLon(), event.getLat(), ts);
 
-                Pointer tpoint = functions.tgeogpoint_in(tpointWkt);
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(tpointWkt);
                 if (tpoint == null) { log.error("tgeogpoint_in returned null for WKT: {}", tpointWkt); continue; }
 
                 for (int i = 0; i < hazardZones.length; i++) {
                     if (hazardZones[i] == null) continue;
                     // Paper Line 2: edwithin_tgeo_geo returns 1 if tpoint is within
                     // distanceMeters of the zone polygon at any instant.
-                    if (functions.edwithin_tgeo_geo(tpoint, hazardZones[i], distanceMeters) == 1) {
+                    if (GeneratedFunctions.edwithin_tgeo_geo(tpoint, hazardZones[i], distanceMeters) == 1) {
                         String alert = String.format(
                                 "[ALERT][Q1] DeviceID=%-6d | lon=%10.5f lat=%9.5f"
                                         + " | ts=%s | within %.0f m of ZONE %d | window [%s - %s]",

--- a/flink-processor/src/main/java/sncbdata/Query2_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query2_Main.java
@@ -15,7 +15,7 @@ import org.apache.flink.util.Collector;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.MeosErrorHandler;
 import functions.error_handler_fn;
 import java.time.Duration;
@@ -66,8 +66,8 @@ public class Query2_Main {
 
         try {
             logger.info("Initializing MEOS library");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new MeosErrorHandler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new MeosErrorHandler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -112,7 +112,7 @@ public class Query2_Main {
             throw e;
         } finally {
             try {
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -144,12 +144,12 @@ public class Query2_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new MeosErrorHandler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
             // Parse maintenance area polygons once per worker
             maintenanceZones = new Pointer[maintenanceAreasWkt.length];
             for (int i = 0; i < maintenanceAreasWkt.length; i++) {
-                maintenanceZones[i] = functions.geog_in(maintenanceAreasWkt[i], -1);
+                maintenanceZones[i] = GeneratedFunctions.geog_in(maintenanceAreasWkt[i], -1);
                 if (maintenanceZones[i] == null) {
                     log.error("geog_in returned null for maintenance area {}", i + 1);
                 }
@@ -168,7 +168,7 @@ public class Query2_Main {
                 String timestamp = millisToTimestamp(elem.getTimestamp());
                 String point = String.format("Point(%f %f)@%s", elem.getLon(), elem.getLat(), timestamp);
 
-                Pointer tpoint = functions.tgeogpoint_in(point);
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(point);
                 if (tpoint == null) {
                     log.error("tgeogpoint_in returned null for WKT: {}", point);
                     continue;
@@ -178,7 +178,7 @@ public class Query2_Main {
                 boolean inMaintenanceArea = false;
                 for (Pointer zone : maintenanceZones) {
                     if (zone == null) continue;
-                    if (functions.eintersects_tgeo_geo(tpoint, zone) == 1) {
+                    if (GeneratedFunctions.eintersects_tgeo_geo(tpoint, zone) == 1) {
                         inMaintenanceArea = true;
                         log.debug("MMSI={} skipped: point intersects maintenance area at ts={}",
                                 deviceId, timestamp);

--- a/flink-processor/src/main/java/sncbdata/Query3_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query3_Main.java
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import functions.GeneratedFunctions;
 import jnr.ffi.Memory;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
@@ -24,7 +25,7 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 import types.temporal.TInterpolation;
@@ -64,8 +65,8 @@ public class Query3_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -100,7 +101,7 @@ public class Query3_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -125,8 +126,8 @@ public class Query3_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -150,7 +151,7 @@ public class Query3_Main {
             }
             seq.append("}");
 
-            Pointer trajectory = functions.tgeogpoint_in(seq.toString());
+            Pointer trajectory = GeneratedFunctions.tgeogpoint_in(seq.toString());
             if (trajectory == null) {
                 log.error("[V1] tgeogpoint_in returned null for sequence: {}", seq);
                 return;
@@ -184,8 +185,8 @@ public class Query3_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -207,7 +208,7 @@ public class Query3_Main {
             for (SNCBData event : sorted) {
                 String wkt   = String.format("POINT(%f %f)@%s",
                         event.getLon(), event.getLat(), millisToTs(event.getTimestamp()));
-                Pointer inst = functions.tgeogpoint_in(wkt);
+                Pointer inst = GeneratedFunctions.tgeogpoint_in(wkt);
                 if (inst == null) {
                     log.error("[V2] tgeogpoint_in returned null for DeviceID={} wkt={}", deviceId, wkt);
                     continue;
@@ -217,7 +218,7 @@ public class Query3_Main {
                     // Seed the expandable sequence with the first instant.
                     Pointer seedArray = Memory.allocate(runtime, Long.BYTES);
                     seedArray.putPointer(0, inst);
-                    trajectory = functions.tsequence_make(
+                    trajectory = GeneratedFunctions.tsequence_make(
                             seedArray, 1, true, true, TInterpolation.LINEAR.getValue(), true);
                     if (trajectory == null) {
                         log.error("[V2] tsequence_make (seed) returned null for DeviceID={}", deviceId);
@@ -225,7 +226,7 @@ public class Query3_Main {
                     }
                 } else {
                     // Append: MEOS expands capacity as needed.
-                    Pointer expanded = functions.temporal_append_tinstant(
+                    Pointer expanded = GeneratedFunctions.temporal_append_tinstant(
                             trajectory, inst, TInterpolation.LINEAR.getValue(), 0.0, null, true);
                     if (expanded == null) {
                         log.error("[V2] temporal_append_tinstant returned null for DeviceID={} wkt={}", deviceId, wkt);
@@ -253,7 +254,7 @@ public class Query3_Main {
                              int deviceId, int points,
                              String windowStart, String windowEnd,
                              Pointer trajectory) {
-        String trajectoryWkt = functions.tspatial_as_ewkt(trajectory, 6);
+        String trajectoryWkt = GeneratedFunctions.tspatial_as_ewkt(trajectory, 6);
         String output = String.format(
                 "[TRAJ][Q3][%s] DeviceID=%-6d | points=%3d | window [%s - %s]%n"
                         + "              trajectory: %s",

--- a/flink-processor/src/main/java/sncbdata/Query4_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query4_Main.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 import types.temporal.TInterpolation;
@@ -74,8 +74,8 @@ public class Query4_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -112,7 +112,7 @@ public class Query4_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -148,11 +148,11 @@ public class Query4_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
-            Pointer tspan = functions.tstzspan_in(tspanLiteral);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+            Pointer tspan = GeneratedFunctions.tstzspan_in(tspanLiteral);
             if (tspan == null) { log.error("tstzspan_in returned null for: {}", tspanLiteral); return; }
-            stbox = functions.stbox_make(true, false, true, 4326, xmin, xmax, ymin, ymax, 0, 0, tspan);
+            stbox = GeneratedFunctions.stbox_make(true, false, true, 4326, xmin, xmax, ymin, ymax, 0, 0, tspan);
             if (stbox == null) log.error("stbox_make returned null");
             else log.info("[V1] STBox built: xmin={} xmax={} ymin={} ymax={} tspan={}",
                     xmin, xmax, ymin, ymax, tspanLiteral);
@@ -170,10 +170,10 @@ public class Query4_Main {
 
             for (SNCBData event : elements) {
                 String ts = millisToTs(event.getTimestamp());
-                Pointer tpoint = functions.tgeogpoint_in(
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", event.getLon(), event.getLat(), ts));
                 if (tpoint == null) continue;
-                if (functions.tgeo_at_stbox(tpoint, stbox, true) == null) continue;
+                if (GeneratedFunctions.tgeo_at_stbox(tpoint, stbox, true) == null) continue;
                 surviving.add(event);
             }
 
@@ -189,7 +189,7 @@ public class Query4_Main {
             }
             seq.append("}");
 
-            Pointer trajectory = functions.tgeogpoint_in(seq.toString());
+            Pointer trajectory = GeneratedFunctions.tgeogpoint_in(seq.toString());
             if (trajectory == null) { log.error("[V1] tgeogpoint_in returned null for seq: {}", seq); return; }
 
             emit(out, log, "V1", deviceId, surviving.size(), windowStart, windowEnd, trajectory);
@@ -231,11 +231,11 @@ public class Query4_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
-            Pointer tspan = functions.tstzspan_in(tspanLiteral);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+            Pointer tspan = GeneratedFunctions.tstzspan_in(tspanLiteral);
             if (tspan == null) { log.error("tstzspan_in returned null for: {}", tspanLiteral); return; }
-            stbox = functions.stbox_make(true, false, true, 4326, xmin, xmax, ymin, ymax, 0, 0, tspan);
+            stbox = GeneratedFunctions.stbox_make(true, false, true, 4326, xmin, xmax, ymin, ymax, 0, 0, tspan);
             if (stbox == null) log.error("stbox_make returned null");
             else log.info("[V2] STBox built: xmin={} xmax={} ymin={} ymax={} tspan={}",
                     xmin, xmax, ymin, ymax, tspanLiteral);
@@ -263,26 +263,26 @@ public class Query4_Main {
             for (SNCBData event : sorted) {
                 String wkt   = String.format("POINT(%f %f)@%s",
                         event.getLon(), event.getLat(), millisToTs(event.getTimestamp()));
-                Pointer inst = functions.tgeogpoint_in(wkt);
+                Pointer inst = GeneratedFunctions.tgeogpoint_in(wkt);
                 if (inst == null) {
                     log.error("[V2] tgeogpoint_in returned null for DeviceID={} wkt={}", deviceId, wkt);
                     continue;
                 }
 
                 // STBox filter: reuse the already-parsed instant pointer.
-                if (functions.tgeo_at_stbox(inst, stbox, true) == null) continue;
+                if (GeneratedFunctions.tgeo_at_stbox(inst, stbox, true) == null) continue;
 
                 if (trajectory == null) {
                     Pointer seedArray = Memory.allocate(runtime, Long.BYTES);
                     seedArray.putPointer(0, inst);
-                    trajectory = functions.tsequence_make(
+                    trajectory = GeneratedFunctions.tsequence_make(
                             seedArray, 1, true, true, TInterpolation.LINEAR.getValue(), true);
                     if (trajectory == null) {
                         log.error("[V2] tsequence_make (seed) returned null for DeviceID={}", deviceId);
                         return;
                     }
                 } else {
-                    Pointer expanded = functions.temporal_append_tinstant(
+                    Pointer expanded = GeneratedFunctions.temporal_append_tinstant(
                             trajectory, inst, TInterpolation.LINEAR.getValue(), 0.0, null, true);
                     if (expanded == null) {
                         log.error("[V2] temporal_append_tinstant returned null for DeviceID={} wkt={}", deviceId, wkt);
@@ -314,7 +314,7 @@ public class Query4_Main {
                 "[TRAJ][Q4][%s] DeviceID=%-6d | points=%3d | window [%s - %s]%n"
                         + "              trajectory: %s",
                 version, deviceId, points, windowStart, windowEnd,
-                functions.tspatial_as_ewkt(trajectory, 6));
+                GeneratedFunctions.tspatial_as_ewkt(trajectory, 6));
         log.info(output);
         out.collect(output);
     }

--- a/flink-processor/src/main/java/sncbdata/Query5_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query5_Main.java
@@ -24,7 +24,7 @@ import org.apache.flink.util.Collector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 import functions.error_handler_fn;
 import types.temporal.TInterpolation;
@@ -84,8 +84,8 @@ public class Query5_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -124,7 +124,7 @@ public class Query5_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -164,9 +164,9 @@ public class Query5_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
-            geofence = functions.geog_in(geofenceWkt, -1);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+            geofence = GeneratedFunctions.geog_in(geofenceWkt, -1);
             if (geofence == null) log.error("[V1] geog_in returned null for geofence: {}", geofenceWkt);
         }
 
@@ -183,9 +183,9 @@ public class Query5_Main {
             for (SNCBData event : elements) {
                 String wkt    = String.format("POINT(%f %f)@%s",
                         event.getLon(), event.getLat(), millisToTs(event.getTimestamp()));
-                Pointer tpoint = functions.tgeogpoint_in(wkt);
+                Pointer tpoint = GeneratedFunctions.tgeogpoint_in(wkt);
                 if (tpoint == null) continue;
-                if (functions.edwithin_tgeo_geo(tpoint, geofence, geofenceDistMeters) != 1) continue;
+                if (GeneratedFunctions.edwithin_tgeo_geo(tpoint, geofence, geofenceDistMeters) != 1) continue;
                 surviving.add(event);
             }
 
@@ -213,9 +213,9 @@ public class Query5_Main {
             // Line 6: (avg_speed > 50) || (min_speed > 20) in m/s
             if (avgSpeedMs <= avgSpeedThresholdMs && minSpeedMs <= minSpeedThresholdMs) return;
 
-            Pointer trajectory = functions.tgeogpoint_in(seq.toString());
+            Pointer trajectory = GeneratedFunctions.tgeogpoint_in(seq.toString());
             String trajectoryEwkt = (trajectory != null)
-                    ? functions.tspatial_as_ewkt(trajectory, 6) : seq.toString();
+                    ? GeneratedFunctions.tspatial_as_ewkt(trajectory, 6) : seq.toString();
 
             emit(out, log, "V1", deviceId, survivingListSize, avgSpeedMs, minSpeedMs,
                     avgSpeedThresholdMs, minSpeedThresholdMs, windowStart, windowEnd, trajectoryEwkt);
@@ -261,9 +261,9 @@ public class Query5_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
-            geofence = functions.geog_in(geofenceWkt, -1);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
+            geofence = GeneratedFunctions.geog_in(geofenceWkt, -1);
             if (geofence == null) log.error("[V2] geog_in returned null for geofence: {}", geofenceWkt);
         }
 
@@ -291,14 +291,14 @@ public class Query5_Main {
             for (SNCBData event : sorted) {
                 String wkt    = String.format("POINT(%f %f)@%s",
                         event.getLon(), event.getLat(), millisToTs(event.getTimestamp()));
-                Pointer inst = functions.tgeogpoint_in(wkt);
+                Pointer inst = GeneratedFunctions.tgeogpoint_in(wkt);
                 if (inst == null) {
                     log.error("[V2] tgeogpoint_in returned null for DeviceID={} wkt={}", deviceId, wkt);
                     continue;
                 }
 
                 // Geofence filter: reuse the already-parsed instant pointer.
-                if (functions.edwithin_tgeo_geo(inst, geofence, geofenceDistMeters) != 1) continue;
+                if (GeneratedFunctions.edwithin_tgeo_geo(inst, geofence, geofenceDistMeters) != 1) continue;
 
                 double speedMs = event.getGpsSpeed() * KMH_TO_MS;
                 speedSumMs += speedMs;
@@ -307,14 +307,14 @@ public class Query5_Main {
                 if (trajectory == null) {
                     Pointer seedArray = Memory.allocate(runtime, Long.BYTES);
                     seedArray.putPointer(0, inst);
-                    trajectory = functions.tsequence_make(
+                    trajectory = GeneratedFunctions.tsequence_make(
                             seedArray, 1, true, true, TInterpolation.LINEAR.getValue(), true);
                     if (trajectory == null) {
                         log.error("[V2] tsequence_make (seed) returned null for DeviceID={}", deviceId);
                         return;
                     }
                 } else {
-                    Pointer expanded = functions.temporal_append_tinstant(
+                    Pointer expanded = GeneratedFunctions.temporal_append_tinstant(
                             trajectory, inst, TInterpolation.LINEAR.getValue(), 0.0, null, true);
                     if (expanded == null) {
                         log.error("[V2] temporal_append_tinstant returned null for DeviceID={} wkt={}", deviceId, wkt);
@@ -330,7 +330,7 @@ public class Query5_Main {
             double avgSpeedMs = speedSumMs / count;
             if (avgSpeedMs <= avgSpeedThresholdMs && minSpeedMs <= minSpeedThresholdMs) return;
 
-            String trajectoryEwkt = functions.tspatial_as_ewkt(trajectory, 6);
+            String trajectoryEwkt = GeneratedFunctions.tspatial_as_ewkt(trajectory, 6);
             emit(out, log, "V2", deviceId, count, avgSpeedMs, minSpeedMs,
                     avgSpeedThresholdMs, minSpeedThresholdMs, windowStart, windowEnd, trajectoryEwkt);
         }

--- a/flink-processor/src/main/java/sncbdata/Query6_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query6_Main.java
@@ -12,7 +12,7 @@ import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindo
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler_fn;
 import functions.MeosErrorHandler;
 
@@ -30,8 +30,8 @@ public class Query6_Main {
 
         try {
             logger.info("Initializing MEOS");
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new MeosErrorHandler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new MeosErrorHandler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -87,7 +87,7 @@ public class Query6_Main {
         } finally {
             try {
                 logger.info("Finalizing MEOS");
-                functions.meos_finalize();
+                GeneratedFunctions.meos_finalize();
             } catch (Exception e) {
                 logger.error("Error during MEOS finalization: {}", e.getMessage(), e);
             }
@@ -109,8 +109,8 @@ public class Query6_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new MeosErrorHandler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -121,8 +121,8 @@ public class Query6_Main {
             String pointLeft = String.format("Point(%f %f)@%s", left.getLon(), left.getLat(), tsLeft);
             String pointRight = String.format("Point(%f %f)@%s", right.getLon(), right.getLat(), tsRight);
 
-            Pointer tpointLeft = functions.tgeogpoint_in(pointLeft);
-            Pointer tpointRight = functions.tgeogpoint_in(pointRight);
+            Pointer tpointLeft = GeneratedFunctions.tgeogpoint_in(pointLeft);
+            Pointer tpointRight = GeneratedFunctions.tgeogpoint_in(pointRight);
 
             if (tpointLeft == null || tpointRight == null) {
                 log.error("tgeogpoint_in returned null for DeviceID={}", left.getDeviceId());
@@ -132,14 +132,14 @@ public class Query6_Main {
             // Paper Line 4: nearest approach distance approximated via geog_distance.
             // nad_tgeo_tgeo requires temporal overlap: for TInstants at different timestamps
             // it returns Double.MAX_VALUE, so we use geog_distance on extracted geography points.
-            Pointer geoLeft  = functions.tgeo_end_value(tpointLeft);
-            Pointer geoRight = functions.tgeo_end_value(tpointRight);
+            Pointer geoLeft  = GeneratedFunctions.tgeo_end_value(tpointLeft);
+            Pointer geoRight = GeneratedFunctions.tgeo_end_value(tpointRight);
             if (geoLeft == null || geoRight == null) {
                 log.error("temporal_end_value returned null for DeviceID={}", left.getDeviceId());
                 return null;
             }
 
-            double mindist = functions.geog_distance(geoLeft, geoRight);
+            double mindist = GeneratedFunctions.geog_distance(geoLeft, geoRight);
 
             // Paper Line 5: lat > 0.0.
             if (left.getLat() <= 0.0 || right.getLat() <= 0.0) return null;

--- a/flink-processor/src/main/java/sncbdata/Query7_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query7_Main.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -58,8 +58,8 @@ public class Query7_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -103,7 +103,7 @@ public class Query7_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -126,8 +126,8 @@ public class Query7_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -146,18 +146,18 @@ public class Query7_Main {
             List<Pointer> geoLefts = new ArrayList<>(lefts.size());
             for (SNCBData left : lefts) {
                 String ts = millisToTimestamp(left.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", left.getLon(), left.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoLefts.add(geo);
             }
 
             List<Pointer> geoRights = new ArrayList<>(rights.size());
             for (SNCBData right : rights) {
                 String ts = millisToTimestamp(right.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", right.getLon(), right.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoRights.add(geo);
             }
 
@@ -180,7 +180,7 @@ public class Query7_Main {
                     // Paper Line 2: device_id < device_id2
                     if (left.getDeviceId() >= right.getDeviceId()) continue;
 
-                    double dist = functions.geog_distance(geoLeft, geoRight);
+                    double dist = GeneratedFunctions.geog_distance(geoLeft, geoRight);
                     String key = left.getDeviceId() + ":" + right.getDeviceId();
                     if (!pairMap.containsKey(key) || dist < pairMap.get(key)[2]) {
                         pairMap.put(key, new double[]{

--- a/flink-processor/src/main/java/sncbdata/Query8_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query8_Main.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -67,8 +67,8 @@ public class Query8_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -101,7 +101,7 @@ public class Query8_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -129,8 +129,8 @@ public class Query8_Main {
         @Override
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
         }
 
         @Override
@@ -168,8 +168,8 @@ public class Query8_Main {
             rawSeq.append("}");
             smoothedSeq.append("}");
 
-            Pointer rawTraj      = functions.tgeogpoint_in(rawSeq.toString());
-            Pointer smoothedTraj = functions.tgeogpoint_in(smoothedSeq.toString());
+            Pointer rawTraj      = GeneratedFunctions.tgeogpoint_in(rawSeq.toString());
+            Pointer smoothedTraj = GeneratedFunctions.tgeogpoint_in(smoothedSeq.toString());
             if (rawTraj == null || smoothedTraj == null) return;
 
             String result = String.format(
@@ -178,8 +178,8 @@ public class Query8_Main {
                             + "         raw:      %s%n"
                             + "         smoothed: %s",
                     deviceId, sorted.size(), gate, q, variance, windowStart, windowEnd,
-                    functions.tspatial_as_ewkt(rawTraj, 6),
-                    functions.tspatial_as_ewkt(smoothedTraj, 6));
+                    GeneratedFunctions.tspatial_as_ewkt(rawTraj, 6),
+                    GeneratedFunctions.tspatial_as_ewkt(smoothedTraj, 6));
 
             log.info(result);
             out.collect(result);

--- a/flink-processor/src/main/java/sncbdata/Query8_V2_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query8_V2_Main.java
@@ -57,7 +57,7 @@ import types.temporal.TInterpolation;
  *
  * <h2>Build requirement</h2>
  * <p>Requires {@code libmeos.so} compiled from the {@code marianaGarcez/MobilityDB}
- * fork (branch {@code master}) and {@code functions.java} patched to expose
+ * fork (branch {@code master}) and {@code GeneratedFunctions.java} patched to expose
  * {@code temporal_ext_kalman_filter}, both handled by {@code Dockerfile.q8v2}.
  *
  * <p><b>HOW TO RUN:</b>
@@ -81,8 +81,8 @@ public class Query8_V2_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -115,7 +115,7 @@ public class Query8_V2_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -147,8 +147,8 @@ public class Query8_V2_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -169,15 +169,15 @@ public class Query8_V2_Main {
                 SNCBData event = sorted.get(0);
                 String wkt   = String.format("POINT(%f %f)@%s",
                         event.getLon(), event.getLat(), millisToTs(event.getTimestamp()));
-                Pointer inst = functions.tgeompoint_in(wkt);
+                Pointer inst = GeneratedFunctions.tgeompoint_in(wkt);
                 if (inst == null) return;
                 Runtime runtime = Runtime.getSystemRuntime();
                 Pointer seedArray = Memory.allocate(runtime, Long.BYTES);
                 seedArray.putPointer(0, inst);
-                Pointer singleSeq = functions.tsequence_make(
+                Pointer singleSeq = GeneratedFunctions.tsequence_make(
                         seedArray, 1, true, true, TInterpolation.LINEAR.getValue(), true);
                 if (singleSeq == null) return;
-                String ewkt = functions.tspatial_as_ewkt(singleSeq, 6);
+                String ewkt = GeneratedFunctions.tspatial_as_ewkt(singleSeq, 6);
                 String result = String.format(
                         "[EKF-V2][Q8] DeviceID=%-6d | points=1 | EKF skipped (single point)"
                                 + " | window [%s - %s]%n"
@@ -195,7 +195,7 @@ public class Query8_V2_Main {
             for (SNCBData event : sorted) {
                 String wkt   = String.format("POINT(%f %f)@%s",
                         event.getLon(), event.getLat(), millisToTs(event.getTimestamp()));
-                Pointer inst = functions.tgeompoint_in(wkt);
+                Pointer inst = GeneratedFunctions.tgeompoint_in(wkt);
                 if (inst == null) {
                     log.error("[EKF-V2] tgeompoint_in returned null for DeviceID={} wkt={}", deviceId, wkt);
                     continue;
@@ -209,7 +209,7 @@ public class Query8_V2_Main {
             for (int i = 0; i < instants.size(); i++) {
                 ptrArray.putPointer((long) i * Long.BYTES, instants.get(i));
             }
-            Pointer rawSeq = functions.tsequence_make(
+            Pointer rawSeq = GeneratedFunctions.tsequence_make(
                     ptrArray, instants.size(), true, true, TInterpolation.LINEAR.getValue(), true);
             if (rawSeq == null) {
                 log.error("[EKF-V2] tsequence_make returned null for DeviceID={}", deviceId);
@@ -230,8 +230,8 @@ public class Query8_V2_Main {
             }
 
             // 5. Format output: raw and cleaned EWKT side-by-side.
-            String rawEwkt     = functions.tspatial_as_ewkt(rawSeq, 6);
-            String cleanedEwkt = functions.tspatial_as_ewkt(cleanedSeq, 6);
+            String rawEwkt     = GeneratedFunctions.tspatial_as_ewkt(rawSeq, 6);
+            String cleanedEwkt = GeneratedFunctions.tspatial_as_ewkt(cleanedSeq, 6);
 
             String result = String.format(
                     "[EKF-V2][Q8] DeviceID=%-6d | points=%2d | gate=%.1f q=%.2e r=%.2e drop=%b"

--- a/flink-processor/src/main/java/sncbdata/Query9_Main.java
+++ b/flink-processor/src/main/java/sncbdata/Query9_Main.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jnr.ffi.Pointer;
-import functions.functions;
+import functions.GeneratedFunctions;
 import functions.error_handler;
 
 /**
@@ -60,8 +60,8 @@ public class Query9_Main {
         logger.info("Java library path: {}", System.getProperty("java.library.path"));
 
         try {
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(new error_handler());
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(new error_handler());
 
             final StreamExecutionEnvironment env =
                     StreamExecutionEnvironment.getExecutionEnvironment();
@@ -104,7 +104,7 @@ public class Query9_Main {
             logger.error("Error during execution: {}", e.getMessage(), e);
             throw e;
         } finally {
-            try { functions.meos_finalize(); }
+            try { GeneratedFunctions.meos_finalize(); }
             catch (Exception e) { logger.error("Error during MEOS finalization: {}", e.getMessage(), e); }
         }
     }
@@ -128,8 +128,8 @@ public class Query9_Main {
         public void open(OpenContext parameters) throws Exception {
             super.open(parameters);
             errorHandler = new error_handler();
-            functions.meos_initialize_timezone("UTC");
-            functions.meos_initialize_error_handler(errorHandler);
+            GeneratedFunctions.meos_initialize_timezone("UTC");
+            GeneratedFunctions.meos_initialize_error_handler(errorHandler);
         }
 
         @Override
@@ -148,18 +148,18 @@ public class Query9_Main {
             List<Pointer> geoLefts = new ArrayList<>(lefts.size());
             for (SNCBData left : lefts) {
                 String ts = millisToTimestamp(left.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", left.getLon(), left.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoLefts.add(geo);
             }
 
             List<Pointer> geoRights = new ArrayList<>(rights.size());
             for (SNCBData right : rights) {
                 String ts = millisToTimestamp(right.getTimestamp());
-                Pointer tp  = functions.tgeogpoint_in(
+                Pointer tp  = GeneratedFunctions.tgeogpoint_in(
                         String.format("POINT(%f %f)@%s", right.getLon(), right.getLat(), ts));
-                Pointer geo = (tp != null) ? functions.tgeo_end_value(tp) : null;
+                Pointer geo = (tp != null) ? GeneratedFunctions.tgeo_end_value(tp) : null;
                 geoRights.add(geo);
             }
 
@@ -183,7 +183,7 @@ public class Query9_Main {
                     // Paper Line 2: device_id != device_id2
                     if (left.getDeviceId() == right.getDeviceId()) continue;
 
-                    double dist = functions.geog_distance(geoLeft, geoRight);
+                    double dist = GeneratedFunctions.geog_distance(geoLeft, geoRight);
                     String key = left.getDeviceId() + "->" + right.getDeviceId();
                     if (!minDistMap.containsKey(key) || dist < minDistMap.get(key)[2]) {
                         minDistMap.put(key, new double[]{


### PR DESCRIPTION
Upgrading `functions` to `GeneratedFunctions` to fit JMEOS updates because `functions` will eventually be deprecated