### PR TITLE
Add CI: build libmeos from the recorded commit and run the smoke tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,67 @@
+name: Maven CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  # ── Linux ────────────────────────────────────────────────────────────────────
+  linux:
+    name: Build and test — Linux (Java 21 / Flink 2.0)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Install MEOS build dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y \
+            cmake ninja-build \
+            libjson-c-dev libgeos-dev libproj-dev libgsl-dev libh3-dev libgdal-dev
+
+      - name: Resolve the MEOS source commit
+        id: meos
+        # The bundled JMEOS jar and the generated MeosOps* facades are produced from one
+        # upstream MobilityDB commit, recorded once in tools/meos-source-commit.txt. CI reads
+        # it so the libmeos the smoke tests load stays in lockstep with the vendored surface —
+        # bumping the surface is a single edit there, with no SHA duplicated in this workflow.
+        run: echo "sha=$(tr -d '[:space:]' < tools/meos-source-commit.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout MobilityDB source (for MEOS build)
+        uses: actions/checkout@v4
+        with:
+          repository: MobilityDB/MobilityDB
+          ref: ${{ steps.meos.outputs.sha }}
+          path: MobilityDB-src
+
+      - name: Build and install libmeos.so
+        run: |
+          # The build dir lives inside MobilityDB-src so the vendored pgtypes headers
+          # ("../../meos/include/...") resolve against the source tree. The family set matches
+          # the surface the bundled jar + facades were generated from.
+          cmake -S MobilityDB-src -B MobilityDB-src/meos-build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DMEOS=ON \
+            -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON -DQUADBIN=ON -DRASTER=ON \
+            -DH3=ON \
+            -DH3_LIBRARY=/usr/lib/x86_64-linux-gnu/libh3.so \
+            -DH3_INCLUDE_DIR=/usr/include/h3
+          cmake --build MobilityDB-src/meos-build --target meos -j
+          sudo cmake --install MobilityDB-src/meos-build
+
+      - name: Build + generate + smoke tests
+        # The generated MeosOps* facades forward to the bundled JMEOS jar (system-scoped); the
+        # smoke tests exercise them against the freshly built libmeos, resolved from
+        # /usr/local/lib rather than the committed lib/ copy.
+        working-directory: flink-processor
+        run: mvn -B -Dmeos.lib.dir=/usr/local/lib -Dmeos.enabled=true clean test

--- a/tools/meos-source-commit.txt
+++ b/tools/meos-source-commit.txt
@@ -1,0 +1,1 @@
+ed3f13ef4c7cdea8a448bb152c0247dd647d2dbd


### PR DESCRIPTION
MobilityFlink had no CI, so a facade or MEOS-surface regression could only be caught by running the smoke tests by hand. This adds a GitHub Actions workflow that:

- reads the MobilityDB commit recorded in `tools/meos-source-commit.txt`,
- builds and installs `libmeos` from it with the family set the bundled JMEOS jar and the generated `MeosOps*` facades correspond to (`-DCBUFFER -DNPOINT -DPOSE -DRGEO -DQUADBIN -DRASTER -DH3`), and
- runs the `flink-processor` smoke tests against it (resolved from `/usr/local/lib`, not the committed `lib/` copy).

`tools/meos-source-commit.txt` records that commit as a plain upstream SHA, so bumping the vendored surface is a single edit there with no SHA duplicated in the workflow — the same shape MobilitySpark uses.

Verified locally: `mvn -B -Dmeos.enabled=true clean test` in `flink-processor` is **12/0/0** against a `libmeos` built from the recorded commit with this exact family set.