### PR TITLE
Build libmeos from source instead of vendoring the native binary

### DIFF
--- a/flink-processor/pom.xml
+++ b/flink-processor/pom.xml
@@ -25,11 +25,12 @@
         <kafka.version>3.2.0</kafka.version>
         <log4j.version>2.17.2</log4j.version>
         <target.java.version>21</target.java.version>
-        <!-- MEOS smoke tests run when libmeos is present; the runner resolves it
-             through the repo lib via LD_LIBRARY_PATH (avoids a stale system
-             /usr/local/lib/libmeos.so shadowing the pinned one). -->
+        <!-- MEOS smoke tests run when libmeos is present. libmeos is not vendored: it is
+             built from the tracked MobilityDB commit and installed to /usr/local/lib (CI and
+             the Dockerfiles do this), which meos.lib.dir points at. Override it to point at a
+             local build dir. -->
         <meos.enabled>true</meos.enabled>
-        <meos.lib.dir>${project.basedir}/lib</meos.lib.dir>
+        <meos.lib.dir>/usr/local/lib</meos.lib.dir>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
MobilitySpark commits no native `libmeos.so` — its CI builds it from the tracked MobilityDB commit, installs it to `/usr/local/lib`, and the smoke tests load it from there. MobilityFlink instead committed a 5.9 MB `flink-processor/lib/libmeos.so` and pointed the tests at it with `meos.lib.dir=${basedir}/lib`.

This removes the committed binary and defaults `meos.lib.dir` to `/usr/local/lib`, where the CI workflow and the Dockerfiles already build and install `libmeos` from the tracked MobilityDB commit (the Dockerfiles do not use the committed copy — they `cp /usr/local/lib/libmeos.so`). Override `meos.lib.dir` to point at a local build directory.

Verified: with `flink-processor/lib/libmeos.so` removed, `mvn -B -Dmeos.enabled=true clean test` (pointing `meos.lib.dir` at a `libmeos` built from the tracked commit) is **12/0/0** — the vendored binary was needed by nothing but the test default it now replaces.