### PR TITLE
Build libmeos via the shared provision-meos action

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,33 +21,6 @@ jobs:
           java-version: "21"
           cache: maven
 
-      # Prefer apt.postgresql.org over the runner's preinstalled PostgreSQL so
-      # the postgresql-server-dev package resolves cleanly. Only pg_config is
-      # needed here — pgPointCloud produces a static libpc.a, no server.
-      - name: Remove existing PostgreSQL installations [prefer apt.postgresql.org]
-        run: |
-          sudo service postgresql stop || true
-          sudo apt-get --purge remove postgresql* -y || true
-          sudo rm -rf /var/lib/postgresql/ /etc/postgresql/ \
-            /var/log/postgresql/ || true
-
-      - name: Add PostgreSQL APT repository
-        run: |
-          sudo apt-get install -y curl ca-certificates gnupg
-          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-            | sudo apt-key add -
-          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
-            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-
-      - name: Install MEOS build dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y \
-            cmake ninja-build \
-            libjson-c-dev libgeos-dev libproj-dev libgsl-dev libh3-dev libgdal-dev \
-            libxml2-dev autoconf automake libtool pkg-config \
-            postgresql-17 postgresql-server-dev-17
-
       - name: Resolve the MEOS source commit
         id: meos
         # The bundled JMEOS jar and the generated MeosOps* facades are produced from one
@@ -56,28 +29,14 @@ jobs:
         # bumping the surface is a single edit there, with no SHA duplicated in this workflow.
         run: echo "sha=$(tr -d '[:space:]' < tools/meos-source-commit.txt)" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout MobilityDB source (for MEOS build)
-        uses: actions/checkout@v4
+      # Build and install the all-families libmeos through the shared
+      # provision-meos action so the MEOS build recipe (PG purge, apt.postgresql.org
+      # PG17, deps, cmake --build/--install under /usr/local) lives in one place.
+      - name: Build and install libmeos
+        uses: MobilityDB/MEOS-API/.github/actions/provision-meos@master
         with:
-          repository: MobilityDB/MobilityDB
-          ref: ${{ steps.meos.outputs.sha }}
-          path: MobilityDB-src
-
-      - name: Build and install libmeos.so
-        run: |
-          # The build dir lives inside MobilityDB-src so the vendored pgtypes headers
-          # ("../../meos/include/...") resolve against the source tree. The family set matches
-          # the surface the bundled jar + facades were generated from.
-          cmake -S MobilityDB-src -B MobilityDB-src/meos-build \
-            -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DMEOS=ON \
-            -DALL=ON \
-            -DH3_LIBRARY=/usr/lib/x86_64-linux-gnu/libh3.so \
-            -DH3_INCLUDE_DIR=/usr/include/h3 \
-            -DPOSTGRESQL_PG_CONFIG=/usr/lib/postgresql/17/bin/pg_config
-          cmake --build MobilityDB-src/meos-build --target meos -j
-          sudo cmake --install MobilityDB-src/meos-build
+          mobilitydb-ref: ${{ steps.meos.outputs.sha }}
+          build-libmeos: "true"
 
       - name: Build + generate + smoke tests
         # The generated MeosOps* facades forward to the bundled JMEOS jar (system-scoped); the


### PR DESCRIPTION
CI builds and installs libmeos through the shared provision-meos action instead of an inline copy of the MEOS build recipe, so the all-families build lives in one place. The MobilityDB commit is still taken from tools/meos-source-commit.txt.
